### PR TITLE
fix: Adjust terminal input timing for improved responsiveness

### DIFF
--- a/snake_game.py
+++ b/snake_game.py
@@ -124,7 +124,7 @@ class SnakeGame:
         elif readchar is not None:
             import select
 
-            if select.select([sys.stdin], [], [], 0.02)[0]:
+            if select.select([sys.stdin], [], [], 0.05)[0]:
                 direction = readchar.readchar()
                 if isinstance(direction, bytes):
                     direction = direction.decode()
@@ -158,7 +158,7 @@ class SnakeGame:
                 import termios
                 import tty
 
-                if select.select([sys.stdin], [], [], 0.02)[0]:
+                if select.select([sys.stdin], [], [], 0.05)[0]:
                     fd = sys.stdin.fileno()
                     old_settings = termios.tcgetattr(fd)
                     try:


### PR DESCRIPTION
This commit further refines terminal input handling by adjusting the `select.select` timeout in the `read_input` method. The timeout has been changed from 0.02s back to 0.05s.

This change aims to address issues where your key presses ('w','a','s','d') might not be detected reliably during gameplay, causing the snake to continue in its previous direction. The 0.05s timeout provides a slightly longer window for the system to report input availability within each game tick, which is expected to improve input capture reliability, especially based on your feedback regarding intermittent input success.

This is a further attempt to resolve input issues before considering more complex solutions like threaded input.